### PR TITLE
bug: script didn't work when console wasn't available

### DIFF
--- a/jsLogger.js
+++ b/jsLogger.js
@@ -1,7 +1,7 @@
 window.console=(function(origConsole){
 
-    if(!window.console)
-      console = {};
+    if(!window.console || !origConsole)
+      origConsole = {};
     var isDebug=false,
     logArray = {
       logs: [],


### PR DESCRIPTION
Just a small bug. I tried setting `window.console = undefined` before using your script and I got a `TypeError: origConsole is undefined`.